### PR TITLE
Update metrics to 1.5

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -7,7 +7,6 @@ packages:
     version: 0.9.0
   - package: dbt-labs/metrics
     version: 1.5.0
-    version: 1.3.0
   - package: brooklyn-data/dbt_artifacts
     version: 2.3.0
   - package: dbt-labs/dbt_project_evaluator


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.14.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->
- https://app.asana.com/0/1204502909052868/1204604185345526/f
- https://app.asana.com/0/1204502909052868/1204604186628813/f

In order to upgrade our dbt version to use v1.5, we need to upgrade the metrics package to use v1.5. The CI check will fail for this PR because the metrics package requires dbt v1.5 which is not set on the staging environment. Based on this slack thread, I would like to get this approved and merged in after hours so I can update all of our environments to use v1.5 and so we can use v1.5 of the metrics package

## Checklist:
<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My SQL follows the [dbt Labs style guide](https://github.com/dbt-labs/corp/blob/master/dbt_style_guide.md).