### PR TITLE
Feat: Add sample macro that overrides model yaml macro in "samples" folder

### DIFF
--- a/models/_samples/override_naming_model_yaml.sql
+++ b/models/_samples/override_naming_model_yaml.sql
@@ -1,0 +1,54 @@
+{% macro generate_column_yaml(column, model_yaml, column_desc_dict, parent_column_name="") %}
+    {% if parent_column_name %}
+        {% set column_name = parent_column_name ~ "." ~ column.name %}
+    {% else %}
+        {% set column_name = column.name %}
+    {% endif %}
+-- removing "lower" from whole macro
+    {% do model_yaml.append('      - name: ' ~ column.name) %}
+    {% do model_yaml.append('        description: "' ~ column_desc_dict.get(column.name) ~ '"') %}
+    {% do model_yaml.append('') %}
+
+    {% if column.fields|length > 0 %}
+        {% for child_column in column.fields %}
+            {% set model_yaml = codegen.generate_column_yaml(child_column, model_yaml, column_desc_dict, parent_column_name=column_name) %}
+        {% endfor %}
+    {% endif %}
+    {% do return(model_yaml) %}
+{% endmacro %}
+
+{% macro generate_model_yaml(model_names=[], upstream_descriptions=False) %}
+
+    {% set model_yaml=[] %}
+
+    {% do model_yaml.append('version: 2') %}
+    {% do model_yaml.append('') %}
+    {% do model_yaml.append('models:') %}
+
+    {% if model_names is string %}
+        {{ exceptions.raise_compiler_error("The `model_names` argument must always be a list, even if there is only one model.") }}
+    {% else %}
+        {% for model in model_names %}
+            {% do model_yaml.append('  - name: ' ~ model ) %}
+            {% do model_yaml.append('    description: ""') %}
+            {% do model_yaml.append('    columns:') %}
+
+            {% set relation=ref(model) %}
+            {%- set columns = adapter.get_columns_in_relation(relation) -%}
+            {% set column_desc_dict =  codegen.build_dict_column_descriptions(model) if upstream_descriptions else {} %}
+
+            {% for column in columns %}
+                {% set model_yaml = codegen.generate_column_yaml(column, model_yaml, column_desc_dict) %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
+{% if execute %}
+
+    {% set joined = model_yaml | join ('\n') %}
+    {{ log(joined, info=True) }}
+    {% do return(joined) %}
+
+{% endif %}
+
+{% endmacro %}

--- a/models/_samples/override_naming_model_yaml.sql
+++ b/models/_samples/override_naming_model_yaml.sql
@@ -1,3 +1,5 @@
+--this model override allows users to avoid dbt's "auto lowercasing" behavior when using codegen to generate model yaml. 
+--To actually use this macro, put it in the macros folder and name it generate_model_yaml.sql. 
 {% macro generate_column_yaml(column, model_yaml, column_desc_dict, parent_column_name="") %}
     {% if parent_column_name %}
         {% set column_name = parent_column_name ~ "." ~ column.name %}

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,16 @@
+packages:
+- package: dbt-labs/codegen
+  version: 0.9.0
+- package: dbt-labs/dbt_utils
+  version: 1.1.0
+- package: dbt-labs/audit_helper
+  version: 0.9.0
+- package: brooklyn-data/dbt_artifacts
+  version: 2.6.2
+- package: dbt-labs/dbt_project_evaluator
+  version: 0.6.0
+- package: calogica/dbt_expectations
+  version: 0.8.5
+- package: calogica/dbt_date
+  version: 0.7.2
+sha1_hash: a17b7bdcdb4efda257369bdfd548f5104eb383a3


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.14.0"
-->

## Description & motivation
<!---
Describe your changes, and why you're making them. Is this linked to an open
issue, a Trello card, or another pull request? Link it here.
-->

Some RO groups do not like to use all lowercase. dbt's codegen package natively makes everything lowercase when generating model yaml, and this behavior is really annoying if you use CamelCase. I added a .sql file in the samples folder that removes the "lower" operation from the generate_model_yaml macro so that other groups can override it if they want to. 


I also deleted the rest of the PR template because this change is in isolation. 
